### PR TITLE
Support float operands for multiple instructions.

### DIFF
--- a/dnpatch.script/Script.cs
+++ b/dnpatch.script/Script.cs
@@ -127,14 +127,22 @@ namespace dnpatch.script
                         for (int i = 0; i < instructions.Count; i++)
                         {
                             var instruction = instructions[i];
-                            if (instruction["opcode"] != null && instruction["operand"] != null)
+                            if (instruction["opcode"] != null && instruction["operand"] != null) {
+                                var operand = instruction.Last.Last;
+                                if(operand.Type == JTokenType.Float) {
+                                target.Instructions[i] =
+                                    Instruction.Create((OpCode)GetInstructionField(instruction.First.First.ToString()).GetValue(this),
+                                        instruction.Last.Last.Value<float>());
+                                } else {
                                 target.Instructions[i] =
                                     Instruction.Create((OpCode)GetInstructionField(instruction.First.First.ToString()).GetValue(this),
                                         instruction.Last.Last.Value<dynamic>());
-                            else
+                                }
+                            } else {
                                 target.Instructions[i] =
                                     Instruction.Create(
                                         (OpCode)GetInstructionField(instruction.First.First.ToString()).GetValue(this));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Script instructions with floats didn't seem to work. (Someone tried to use my modder tool with instruction Ldc_R4 and Operand 0.5)
Adding an explicit type of float instead of relying on dynamic seemed to fix the issue.

This is probably going wrong for single instruction scripts as well.